### PR TITLE
Minor UX improvements

### DIFF
--- a/src/player_blink_gui.py
+++ b/src/player_blink_gui.py
@@ -529,6 +529,7 @@ class PlayerBlinkGUI(tk.Frame):
 
         self.s0_1_2_3.insert(1.0,f"{state[0]:08X}\n{state[1]:08X}\n{state[2]:08X}\n{state[3]:08X}")
         self.s01_23.insert(1.0,f"{state[0]:08X}{state[1]:08X}\n{state[2]:08X}{state[3]:08X}")
+        self.enable_reidentify()
 
         self.advances = (1 if self.menu_check_var.get() else 0)
         self.tracking = True


### PR DESCRIPTION
1. Starts with the Monitor, reidentify, and Preview buttons disabled.
2. Selecting a config or an eye image enables the Monitor and Preview buttons.
3. Reidentify remains disabled until seeds are recorded.
4. Clicking Monitor or Reidentify while preview is showing automatically stops the preview. (Brief visual interruption in view between stopping preview and starting the new view.)
5. While monitoring or reidentifying, the other two buttons are disabled.
6. Clicking Stop Monitoring or Stop Reidentifying returns to preview. (Brief visual interruption in view between stopping and returning to preview.)